### PR TITLE
Allow standard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # emlAnalyzer
-A cli script to analyze an E-Mail in the eml format for viewing the header, extracting attachments etc.
+A CLI script to analyze an email in the EML format for viewing headers, extracting attachments, etc.
 
 ## Installation
 
@@ -11,16 +11,16 @@ Install the package with pip
 Type ```emlAnalyzer --help``` to view the help.
 
 ```
-usage: emlAnalyzer [OPTION]... -i FILE
+usage: emlAnalyzer [-h] [-i [INPUT]] [--header] [-x] [-a] [--text] [--html] [-s] [-u] [-ea EXTRACT] [--extract-all] [-o OUTPUT]
 
-A cli script to analyze an E-Mail in the eml format for viewing the header, extracting attachments etc.
+A CLI script to analyze an email in the EML format for viewing headers, extracting attachments, etc.
 
 optional arguments:
   -h, --help            show this help message and exit
-  -i INPUT, --input INPUT
-                        path to the eml-file (is required)
+  -i [INPUT], --input [INPUT]
+                        Path to the EML file. Accepts standard input if omitted
   --header              Shows the headers
-  -x, --tracking        Shows content which is reloaded from external ressources in the HTML part
+  -x, --tracking        Shows content which is reloaded from external resources in the HTML part
   -a, --attachments     Lists attachments
   --text                Shows plaintext
   --html                Shows HTML

--- a/eml_analyzer/cli_script.py
+++ b/eml_analyzer/cli_script.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 from email import message_from_string
 from email.message import Message
 import re
@@ -243,8 +244,8 @@ def _decode_acii_encoded_utf8_string(string: str) -> str:
 
 
 def main():
-    argument_parser = argparse.ArgumentParser(usage='emlAnalyzer [OPTION]... -i FILE', description='A cli script to analyze an E-Mail in the eml format for viewing the header, extracting attachments etc.')
-    argument_parser.add_argument('-i', '--input', help="path to the eml-file (is required)", type=str)
+    argument_parser = argparse.ArgumentParser(prog='emlAnalyzer', description='A CLI script to analyze an email in the EML format for viewing headers, extracting attachments, etc.')
+    argument_parser.add_argument('--input', '-i', help="Path to the EML file. Accepts standard input if omitted", type=argparse.FileType('r'), nargs='?', default=sys.stdin)
     argument_parser.add_argument('--header', action='store_true', default=False, help="Shows the headers")
     argument_parser.add_argument('-x', '--tracking', action='store_true', default=False, help="Shows content which is reloaded from external resources in the HTML part")
     argument_parser.add_argument('-a', '--attachments', action='store_true', default=False, help="Lists attachments")
@@ -257,17 +258,14 @@ def main():
     argument_parser.add_argument('-o', '--output', type=str, default=None, help="Path for the extracted attachment (default is filename in working directory)")
     arguments = argument_parser.parse_args()
 
-    if arguments.input is None or len(arguments.input) == 0:
-        warning('No Input specified')
+    if not arguments.input:
+        warning('No input specified')
         argument_parser.print_help()
         exit()
 
-    # get the absolute path to the input file
-    path_to_input = os.path.abspath(arguments.input)
-
     # read the eml file
     try:
-        with open(path_to_input, mode='r') as input_file:
+        with arguments.input as input_file:
             eml_content = input_file.read()
     except Exception as e:
         error('Error: {}'.format(e))

--- a/eml_analyzer/cli_script.py
+++ b/eml_analyzer/cli_script.py
@@ -245,7 +245,7 @@ def _decode_acii_encoded_utf8_string(string: str) -> str:
 
 def main():
     argument_parser = argparse.ArgumentParser(prog='emlAnalyzer', description='A CLI script to analyze an email in the EML format for viewing headers, extracting attachments, etc.')
-    argument_parser.add_argument('--input', '-i', help="Path to the EML file. Accepts standard input if omitted", type=argparse.FileType('r'), nargs='?', default=sys.stdin)
+    argument_parser.add_argument('-i', '--input', help="Path to the EML file. Accepts standard input if omitted", type=argparse.FileType('r'), nargs='?', default=sys.stdin)
     argument_parser.add_argument('--header', action='store_true', default=False, help="Shows the headers")
     argument_parser.add_argument('-x', '--tracking', action='store_true', default=False, help="Shows content which is reloaded from external resources in the HTML part")
     argument_parser.add_argument('-a', '--attachments', action='store_true', default=False, help="Lists attachments")


### PR DESCRIPTION
Closes #4 .

I'm not very familiar with Python but this seems to work based on my research:

* https://stackoverflow.com/q/59381035/404623
* https://docs.python.org/3/library/argparse.html#nargs

Test cases:

* relative path: `python3 eml_analyzer/cli_script.py -i ../foo.eml` 
* absolute path: `python3 eml_analyzer/cli_script.py -i /mnt/d/GitHub/foo.eml`
* standard input (implicit): `cat /mnt/d/GitHub/foo.eml | python3 eml_analyzer/cli_script.py`
* standard input (explicit): `cat /mnt/d/GitHub/foo.eml | python3 eml_analyzer/cli_script.py -i -`
* no value: `python3 eml_analyzer/cli_script.py -i` (shows the help text)
* non-existent file: `python3 eml_analyzer/cli_script.py -i qwerty.eml` (shows an error)
* `-i` not specified: `python3 eml_analyzer/cli_script.py` (hangs waiting for end of input)

Notably, running the script without specifying any arguments and without standard input will now hang waiting for end of input. Which is technically expected because the input could be coming in slowly from wherever it is coming from.
Not sure if this is an acceptable change, there might be ways to improve this behaviour but as mentioned before, I am by no means an expert in Python.

Also I'm not sure if there was a purpose to get the absolute path but it did not seem necessary based on my test cases.